### PR TITLE
Improve Solana memecoin tracker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "memecoin_tracker.py", "--interval", "3600"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# crypto-airdrop-
+# Crypto Airdrop Tools
+
+This repository contains utilities for finding early Solana-based memecoins. The scripts
+fetch trending tokens from CoinGecko, apply a heuristic scoring model, and estimate a risk
+level based on volume, market cap, price volatility and token age. Results can be logged
+continuously or run in parallel for higher coverage.
+
+## Requirements
+
+Install dependencies:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+## Usage
+
+Run the tracker once to print any promising coins:
+
+```bash
+python3 memecoin_tracker.py
+```
+
+Each result includes a score and a risk level (``low``, ``medium`` or ``high``)
+to assist with basic risk management.
+
+To run continuously, pass an interval in seconds. Results will be appended to
+`memecoin_log.txt`:
+
+```bash
+python3 memecoin_tracker.py --interval 3600
+```
+
+To run several tracker processes simultaneously, use ``tracker_pool.py``:
+
+```bash
+python3 tracker_pool.py --workers 4 --interval 3600
+```
+
+The legacy helper `run_tracker.py` is kept for compatibility and accepts the
+same `--interval` option.
+
+### Docker
+
+Build and run the tracker in a container:
+
+```bash
+docker build -t memecoin-tracker .
+docker run -it memecoin-tracker
+```
+
+## Tests
+
+Run the unit tests with:
+
+```bash
+python3 -m unittest
+```
+
+The tests use sample historical data stored under `tests/data` to validate the scoring and filtering logic.

--- a/memecoin_tracker.py
+++ b/memecoin_tracker.py
@@ -1,0 +1,160 @@
+"""Utilities to track promising Solana memecoins using CoinGecko data."""
+
+import argparse
+import requests
+import time
+from typing import List, Dict, Tuple
+
+COINGECKO_API = "https://api.coingecko.com/api/v3"
+
+
+def get_trending_coins() -> List[Dict]:
+    """Return the list of trending coins from CoinGecko."""
+
+    url = f"{COINGECKO_API}/search/trending"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return [coin["item"] for coin in data.get("coins", [])]
+
+
+def get_coin_details(coin_id: str) -> Dict:
+    """Retrieve metadata for a coin by id."""
+
+    url = f"{COINGECKO_API}/coins/{coin_id}"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def score_token(details: Dict) -> float:
+    """Compute a simple heuristic score for a coin."""
+
+    market_data = details.get("market_data", {})
+    price_change = market_data.get("price_change_percentage_24h", 0)
+    market_cap = market_data.get("market_cap", {}).get("usd", 0)
+    supply = market_data.get("circulating_supply", 0)
+
+    score = 0.0
+    if price_change is not None:
+        score += max(0.0, float(price_change))
+    if market_cap and market_cap < 50_000_000:
+        score += 20
+    if supply and supply < 1_000_000_000:
+        score += 10
+    return score
+
+
+def calculate_risk(details: Dict) -> Tuple[float, str]:
+    """Return a risk score and label for a coin."""
+
+    market_data = details.get("market_data", {})
+    volume = market_data.get("total_volume", {}).get("usd", 0)
+    market_cap = market_data.get("market_cap", {}).get("usd", 0)
+    price_change = market_data.get("price_change_percentage_24h", 0) or 0
+    genesis = details.get("genesis_date")
+
+    risk = 0.0
+    if volume < 1_000_000:
+        risk += 20
+    if volume < 100_000:
+        risk += 20
+    if market_cap < 10_000_000:
+        risk += 20
+    if market_cap < 1_000_000:
+        risk += 20
+    if abs(float(price_change)) > 50:
+        risk += 20
+    if genesis:
+        try:
+            coin_ts = time.strptime(genesis, "%Y-%m-%d")
+            age_days = (time.time() - time.mktime(coin_ts)) / 86400
+            if age_days < 30:
+                risk += 20
+        except ValueError:
+            pass
+
+    if risk < 40:
+        label = "low"
+    elif risk < 80:
+        label = "medium"
+    else:
+        label = "high"
+    return risk, label
+
+
+def find_potential_memes(threshold: float = 25.0, limit: int = 10) -> List[Dict]:
+    """Return a list of Solana tokens whose score exceeds the threshold."""
+
+    trending = get_trending_coins()
+    results = []
+    for item in trending:
+        coin_id = item.get("id")
+        details = get_coin_details(coin_id)
+        platforms = details.get("platforms", {})
+        if "solana" not in platforms:
+            continue
+        score = score_token(details)
+        risk, label = calculate_risk(details)
+        if score >= threshold:
+            results.append({
+                "name": item.get("name"),
+                "symbol": item.get("symbol"),
+                "score": score,
+                "risk": risk,
+                "risk_label": label,
+                "url": f"https://www.coingecko.com/en/coins/{coin_id}"
+            })
+        if len(results) >= limit:
+            break
+        time.sleep(1)  # avoid spamming the API
+    return results
+
+
+def _print_candidates(candidates: List[Dict], ts: str | None = None, log=None) -> None:
+    """Helper to print and optionally log the list of candidates."""
+
+    if not candidates:
+        prefix = f"[{ts}] " if ts else ""
+        print(f"{prefix}No high-potential Solana memecoins found in trending list.")
+        return
+
+    header = f"[{ts}] Potential Solana Memecoins:" if ts else "Potential Solana Memecoins:" 
+    print(header)
+    for c in candidates:
+        line = (
+            f"{c['name']} ({c['symbol']}): score {c['score']:.2f}"
+            f" - risk {c['risk_label']}\n{c['url']}"
+        )
+        print(line)
+        if log:
+            log.write(
+                f"{ts} - {c['name']} ({c['symbol']}): {c['risk_label']} risk - {c['url']}\n"
+            )
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Entry point for the command line interface."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--threshold", type=float, default=25.0, help="score required to report a coin")
+    parser.add_argument("--limit", type=int, default=10, help="maximum number of results")
+    parser.add_argument("--interval", type=int, help="run continuously with this interval in seconds")
+    args = parser.parse_args(argv)
+
+    def run_once(timestamp: str | None = None, log=None):
+        candidates = find_potential_memes(threshold=args.threshold, limit=args.limit)
+        _print_candidates(candidates, ts=timestamp, log=log)
+
+    if args.interval:
+        while True:
+            ts = time.strftime("%Y-%m-%d %H:%M:%S")
+            with open("memecoin_log.txt", "a") as log:
+                run_once(timestamp=ts, log=log)
+            time.sleep(args.interval)
+    else:
+        run_once()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/run_tracker.py
+++ b/run_tracker.py
@@ -1,0 +1,20 @@
+"""Legacy runner that periodically invokes :mod:`memecoin_tracker`."""
+
+import argparse
+import time
+from memecoin_tracker import main as tracker_main
+
+
+def run(interval: int = 3600) -> None:
+    """Run ``memecoin_tracker`` continuously at the given interval."""
+
+    args = ["--interval", str(interval)]
+    tracker_main(args)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--interval", type=int, default=3600,
+                        help="seconds between checks")
+    args = parser.parse_args()
+    run(args.interval)

--- a/tests/data/coin_non_sol.json
+++ b/tests/data/coin_non_sol.json
@@ -1,0 +1,10 @@
+{
+  "platforms": {"ethereum": "0x123"},
+  "market_data": {
+    "price_change_percentage_24h": 2,
+    "market_cap": {"usd": 200000000},
+    "circulating_supply": 2000000000,
+    "total_volume": {"usd": 500000}
+  },
+  "genesis_date": "2022-01-01"
+}

--- a/tests/data/coin_sol.json
+++ b/tests/data/coin_sol.json
@@ -1,0 +1,10 @@
+{
+  "platforms": {"solana": "So1anaAddress"},
+  "market_data": {
+    "price_change_percentage_24h": 5,
+    "market_cap": {"usd": 5000000},
+    "circulating_supply": 500000000,
+    "total_volume": {"usd": 500000}
+  },
+  "genesis_date": "2025-06-01"
+}

--- a/tests/data/trending.json
+++ b/tests/data/trending.json
@@ -1,0 +1,6 @@
+{
+  "coins": [
+    {"item": {"id": "solana-coin", "name": "SolanaCoin", "symbol": "SC"}},
+    {"item": {"id": "non-sol-coin", "name": "NonSol", "symbol": "NS"}}
+  ]
+}

--- a/tests/test_memecoin_tracker.py
+++ b/tests/test_memecoin_tracker.py
@@ -1,0 +1,54 @@
+import json
+import os
+import unittest
+from unittest.mock import patch, Mock
+
+import memecoin_tracker
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+
+
+def load_json(name):
+    with open(os.path.join(DATA_DIR, name), 'r') as f:
+        return json.load(f)
+
+
+class TestMemecoinTracker(unittest.TestCase):
+    def setUp(self):
+        self.trending = load_json('trending.json')
+        self.coin_sol = load_json('coin_sol.json')
+        self.coin_non_sol = load_json('coin_non_sol.json')
+
+    def fake_get(self, url, timeout=10):
+        mock_resp = Mock()
+        if 'search/trending' in url:
+            mock_resp.json.return_value = self.trending
+        elif 'solana-coin' in url:
+            mock_resp.json.return_value = self.coin_sol
+        else:
+            mock_resp.json.return_value = self.coin_non_sol
+        mock_resp.raise_for_status = lambda: None
+        return mock_resp
+
+    @patch('requests.get')
+    def test_find_potential_memes(self, mock_get):
+        mock_get.side_effect = self.fake_get
+        result = memecoin_tracker.find_potential_memes(threshold=20, limit=5)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], 'SolanaCoin')
+        self.assertIn('solana', result[0]['url'])
+        self.assertEqual(result[0]['risk_label'], 'medium')
+
+    @patch('requests.get')
+    def test_cli_once(self, mock_get):
+        mock_get.side_effect = self.fake_get
+        memecoin_tracker.main(['--threshold', '20', '--limit', '5'])
+
+    def test_calculate_risk(self):
+        risk, label = memecoin_tracker.calculate_risk(self.coin_sol)
+        self.assertTrue(risk > 0)
+        self.assertEqual(label, 'medium')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tracker_pool.py
+++ b/tracker_pool.py
@@ -1,0 +1,25 @@
+"""Run multiple tracker instances in parallel."""
+
+import argparse
+from concurrent.futures import ProcessPoolExecutor
+
+from memecoin_tracker import main as tracker_main
+
+
+def run_parallel(workers: int, interval: int, threshold: float, limit: int) -> None:
+    """Launch several tracker processes with the given options."""
+
+    args = ["--interval", str(interval), "--threshold", str(threshold), "--limit", str(limit)]
+    with ProcessPoolExecutor(max_workers=workers) as exe:
+        for _ in range(workers):
+            exe.submit(tracker_main, args)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workers", type=int, default=2, help="number of parallel trackers")
+    parser.add_argument("--interval", type=int, default=3600, help="seconds between checks")
+    parser.add_argument("--threshold", type=float, default=25.0, help="score required")
+    parser.add_argument("--limit", type=int, default=10, help="max results")
+    args = parser.parse_args()
+    run_parallel(args.workers, args.interval, args.threshold, args.limit)


### PR DESCRIPTION
## Summary
- document how to run the tracker continuously
- add CLI options for `memecoin_tracker.py`
- refactor `run_tracker.py` to reuse the CLI entrypoint
- extend unit tests to cover CLI usage
- add risk scoring with volume, market cap, volatility and token age
- support running multiple trackers in parallel
- provide Dockerfile and detailed usage

## Testing
- `pip3 install -r requirements.txt`
- `python3 -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_6862eaa028e8832b92870b8405793a87